### PR TITLE
Fix demo application

### DIFF
--- a/packages/dev-frontend/src/components/Stability/NoDeposit.tsx
+++ b/packages/dev-frontend/src/components/Stability/NoDeposit.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react';
 import { Card, Heading, Box, Flex, Button, Link } from 'theme-ui';
-import { InfoMessage } from '../InfoMessage';
 import { useStabilityView } from './context/StabilityViewContext';
 import { RemainingLQTY } from './RemainingLQTY';
 import { Yield } from './Yield';

--- a/packages/dev-frontend/src/components/Staking/NoStake.tsx
+++ b/packages/dev-frontend/src/components/Staking/NoStake.tsx
@@ -1,8 +1,5 @@
 import { Card, Heading, Box, Flex, Button, Link } from "theme-ui";
 
-import { GT } from "../../strings";
-
-import { InfoMessage } from "../InfoMessage";
 import { useStakingView } from "./context/StakingViewContext";
 import { Icon } from "../Icon";
 

--- a/packages/dev-frontend/src/components/TokenStats.tsx
+++ b/packages/dev-frontend/src/components/TokenStats.tsx
@@ -165,6 +165,7 @@ export const TokenStats: React.FC = () => {
     }
 
     const d = data["data"];
+    if (!d["token"]) return Decimal.from(0);
     //return Decimal.from(d['token']['derivedETH']).mul(Decimal.from(d['bundle']['ethPrice'])).toString(2);
     return Decimal.from(d["token"]["derivedETH"]).mul(Decimal.from(d["bundle"]["ethPrice"]));
   };

--- a/packages/dev-frontend/src/components/UserAccount.tsx
+++ b/packages/dev-frontend/src/components/UserAccount.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Text, Flex, Box, Heading, Button } from "theme-ui";
+import { Text, Flex, Box, Heading } from "theme-ui";
 
 import { LiquityStoreState } from "@liquity/lib-base";
 import { useLiquitySelector } from "@liquity/lib-react";


### PR DESCRIPTION
In the moment starting the demo application with `yarn start-demo` is failing with the following error:

![Screen Shot 2021-11-12 at 17 11 49](https://user-images.githubusercontent.com/468/141434094-f52815a1-76ea-45a5-8e65-d377005046fd.png)

The problem is that for some reason on fresh development setup `d["token"]` is not defined here - https://github.com/teddy-cash/dev/blob/main/packages/dev-frontend/src/components/TokenStats.tsx#L169

The current PR is fixing this error and removing all linter warning about unused variables.

In order for the demo application to really works [PR# 53](https://github.com/teddy-cash/dev/pull/53) should be merged first

